### PR TITLE
fix mcp on linux

### DIFF
--- a/src/wcgw/client/tools.py
+++ b/src/wcgw/client/tools.py
@@ -13,7 +13,6 @@ import traceback
 import uuid
 from os.path import expanduser
 from pathlib import Path
-import platform
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import (
     Any,
@@ -143,8 +142,6 @@ def start_shell(is_restricted_mode: bool, initial_dir: str) -> pexpect.spawn:  #
         cmd = "/bin/bash"
         if is_restricted_mode:
             cmd += " -r"
-        if platform.system() == "Linux":
-            cmd += " --noprofile --norc"
 
         shell = pexpect.spawn(
             cmd,
@@ -155,6 +152,7 @@ def start_shell(is_restricted_mode: bool, initial_dir: str) -> pexpect.spawn:  #
             cwd=initial_dir,
         )
         shell.sendline(f"export PS1={PROMPT}")
+        shell.expect(PROMPT, timeout=TIMEOUT)
     except Exception as e:
         console.print(traceback.format_exc())
         console.log(f"Error starting shell: {e}. Retrying without rc ...")
@@ -166,8 +164,9 @@ def start_shell(is_restricted_mode: bool, initial_dir: str) -> pexpect.spawn:  #
             encoding="utf-8",
             timeout=TIMEOUT,
         )
+        shell.sendline(f"export PS1={PROMPT}")
+        shell.expect(PROMPT, timeout=TIMEOUT)
 
-    shell.expect(PROMPT, timeout=TIMEOUT)
     shell.sendline("stty -icanon -echo")
     shell.expect(PROMPT, timeout=TIMEOUT)
     shell.sendline("set +o pipefail")

--- a/src/wcgw/client/tools.py
+++ b/src/wcgw/client/tools.py
@@ -13,6 +13,7 @@ import traceback
 import uuid
 from os.path import expanduser
 from pathlib import Path
+import platform
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import (
     Any,
@@ -142,6 +143,8 @@ def start_shell(is_restricted_mode: bool, initial_dir: str) -> pexpect.spawn:  #
         cmd = "/bin/bash"
         if is_restricted_mode:
             cmd += " -r"
+        if platform.system() == "Linux":
+            cmd += " --noprofile --norc"
 
         shell = pexpect.spawn(
             cmd,


### PR DESCRIPTION
## Problem

`wcgw` MCP doesn't work on my pop-os/ubuntu machine. Specifically, when initially connecting to `wcgw` from an MCP client, the connection cannot be established.

## Solution

I traced the issue to starting the shell: the `/bin/bash` hangs and doesn't throw an exception, but simply times out. However, `--noprofile --norc` does work properly.

Proposed solution is to check if we're on a `Linux` platform and, if so, add the `--noprofile --norc` flags. This works on my linux machine.

## Alternative solution

One alternative solution that might work (but I didn't explore) would be to figure out how to get the failing `/bin/bash` to throw an exception rather than just timing out and failing the connection.