### PR TITLE
feat(mcp-server): add customizable server instructions via environment variable

### DIFF
--- a/src/wcgw/client/mcp_server/server.py
+++ b/src/wcgw/client/mcp_server/server.py
@@ -121,11 +121,18 @@ async def handle_call_tool(
     for output_or_done in output_or_dones:
         if isinstance(output_or_done, str):
             if issubclass(tool_type, Initialize):
-                output_or_done += """
+                # Prepare the original hardcoded message
+                original_message = """
 - Additional important note: as soon as you encounter "The user has chosen to disallow the tool call.", immediately stop doing everything and ask user for the reason.
 
 Initialize call done.
     """
+                
+                # If custom instructions exist, prepend them to the original message
+                if CUSTOM_INSTRUCTIONS:
+                    output_or_done += f"\n{CUSTOM_INSTRUCTIONS}\n{original_message}"
+                else:
+                    output_or_done += original_message
 
             content.append(types.TextContent(type="text", text=output_or_done))
         else:
@@ -141,12 +148,16 @@ Initialize call done.
 
 
 BASH_STATE = None
+CUSTOM_INSTRUCTIONS = None
 
 
 async def main() -> None:
-    global BASH_STATE
+    global BASH_STATE, CUSTOM_INSTRUCTIONS
     CONFIG.update(3, 55, 5)
     version = str(importlib.metadata.version("wcgw"))
+    
+    # Read custom instructions from environment variable
+    CUSTOM_INSTRUCTIONS = os.getenv("WCGW_SERVER_INSTRUCTIONS")
 
     # starting_dir is inside tmp dir
     tmp_dir = get_tmpdir()

--- a/uv.lock
+++ b/uv.lock
@@ -1398,7 +1398,7 @@ wheels = [
 
 [[package]]
 name = "wcgw"
-version = "5.3.1"
+version = "5.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Add support for `WCGW_SERVER_INSTRUCTIONS` environment variable to customize MCP server instructions
- Custom instructions are prepended to existing hardcoded Initialize tool response content
- Maintains full backward compatibility when no custom instructions are provided

## Usage
```bash
export WCGW_SERVER_INSTRUCTIONS="Always use proper error handling when making API calls"
wcgw
```