### PR TITLE
Add step to Dockerfile to create 'app:app' user and group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ FROM python:3.12-slim-bookworm
 
 RUN apt-get update && apt-get install -y screen && rm -rf /var/lib/apt/lists/*
 
+# Create app user and group
+RUN groupadd -r app && useradd -r -g app app
+
 # Set the working directory in the container
 WORKDIR /workspace
 


### PR DESCRIPTION
This fixes the following error during `docker build`:

```
[2/2] STEP 4/6: COPY --from=uv --chown=app:app /app/.venv /app/.venv
Error: building at STEP "COPY --from=uv --chown=app:app /app/.venv /app/.venv": looking up UID/GID for "app:app": determining run uid: user: unknown user error looking up user "app"
```