### PR TITLE
fix: Use repo.workdir for git file checks instead of repo.path

### DIFF
--- a/src/wcgw/client/repo_ops/repo_context.py
+++ b/src/wcgw/client/repo_ops/repo_context.py
@@ -167,7 +167,7 @@ def get_repo_context(file_or_repo_path: str) -> tuple[str, Path]:
 
     # Determine the context directory
     if repo is not None:
-        context_dir = Path(repo.path).parent
+        context_dir = Path(repo.workdir) if repo.workdir else Path(repo.path).parent
     else:
         if file_or_repo_path_.is_file():
             context_dir = file_or_repo_path_.parent


### PR DESCRIPTION
When checking whether files changed in a git diff actually exist in the current working directory, Path(repo.path).parent points to the top level root of the main .git directory instead of the specific worktree causing failure for worktrees. By checking repo.workdir instead, we can correctly find the path for worktrees and accurately determine early exits on commit history parsing.