### PR TITLE
Fix MCP session isolation and concurrent tool calls

### DIFF
--- a/src/wcgw/client/bash_state/bash_state.py
+++ b/src/wcgw/client/bash_state/bash_state.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import os
 import platform
-import random
 import re
 import shlex
 import subprocess
@@ -315,8 +314,9 @@ def ensure_wcgw_block_in_rc_file(shell_path: str, console: Console) -> None:
 if [ -n "$IN_WCGW_ENVIRONMENT" ]; then
  PROMPT_COMMAND='printf "◉ $(pwd)──➤ \\r\\e[2K"'
  prmptcmdwcgw() {{ eval "$PROMPT_COMMAND" }}
+ autoload -Uz add-zsh-hook
  add-zsh-hook -d precmd prmptcmdwcgw
- precmd_functions+=prmptcmdwcgw
+ add-zsh-hook precmd prmptcmdwcgw
 fi
 {marker_end}
 """
@@ -346,8 +346,18 @@ fi
         with open(rc_file_path) as f:
             content = f.read()
 
+        if marker_start in content and marker_end in content:
+            block_start = content.index(marker_start)
+            block_end = content.index(marker_end, block_start) + len(marker_end)
+            expected_block = wcgw_block.rstrip("\n")
+            if content[block_start:block_end] == expected_block:
+                return
+            content = content[:block_start] + expected_block + content[block_end:]
+            with open(rc_file_path, "w") as f:
+                f.write(content)
+            console.log(f"Updated WCGW environment block in {rc_file_path}")
+            return
         if marker_start in content:
-            # Block already exists
             return
 
         # Append the block to the file
@@ -401,6 +411,7 @@ def start_shell(
             echo=True,
             encoding="utf-8",
             timeout=CONFIG.timeout,
+            cwd=initial_dir,
             codec_errors="backslashreplace",
         )
         shell.sendline(PROMPT_STATEMENT)
@@ -458,8 +469,8 @@ def get_bash_state_dir_xdg() -> str:
 
 
 def generate_thread_id() -> str:
-    """Generate a random 4-digit thread_id."""
-    return f"i{random.randint(1000, 9999)}"
+    """Generate a collision-resistant thread_id."""
+    return f"i{uuid4().hex}"
 
 
 def save_bash_state_by_id(thread_id: str, bash_state_dict: dict[str, Any]) -> None:
@@ -607,6 +618,10 @@ class BashState:
     @property
     def linesep(self) -> str:
         return self._shell.linesep
+
+    @property
+    def shell_path(self) -> str:
+        return self._shell_path
 
     def sendintr(self) -> None:
         self.close_bg_expect_thread()

--- a/src/wcgw/client/mcp_server/server.py
+++ b/src/wcgw/client/mcp_server/server.py
@@ -14,8 +14,11 @@ from wcgw.client.tool_prompts import TOOL_PROMPTS
 
 from ...types_ import (
     BashCommand,
+    ContextSave,
     FileWriteOrEdit,
     Initialize,
+    ReadFiles,
+    ReadImage,
 )
 from ..bash_state.bash_state import CONFIG, BashState, get_tmpdir
 from ..tools import (
@@ -104,7 +107,6 @@ async def handle_call_tool(
     tool_type = which_tool_name(name)
     tool_call = parse_tool_by_name(name, arguments)
     state = state_for_tool(tool_call)
-    BASH_STATE = state
 
     try:
         output_or_dones, _ = get_tool_output(
@@ -115,7 +117,6 @@ async def handle_call_tool(
             24000,  # coding_max_tokens
             8000,  # noncoding_max_tokens
         )
-        BASH_STATES[state.current_thread_id] = state
 
     except Exception as e:
         output_or_dones = [f"GOT EXCEPTION while calling tool. Error: {e}"]
@@ -153,39 +154,34 @@ Initialize call done.
 BASH_STATE: BashState | None = None
 BASH_STATES: dict[str, BashState] = {}
 CUSTOM_INSTRUCTIONS = None
+STARTING_DIR = ""
+SHELL_PATH = ""
 
 
 def new_state(thread_id: str | None) -> BashState:
-    template = BASH_STATE
-    working_dir = (
-        template.cwd
-        if template is not None
-        else os.path.join(get_tmpdir(), "claude_playground")
-    )
-    use_screen = template.over_screen if template is not None else True
-    shell_path = template.shell_path if template is not None else os.environ.get(
-        "SHELL", "/bin/bash"
-    )
     return BashState(
         Console(),
-        working_dir,
+        STARTING_DIR,
         None,
         None,
         None,
         None,
-        use_screen,
+        True,
         None,
         thread_id,
-        shell_path,
+        SHELL_PATH or None,
     )
 
 
 def tool_thread_id(tool_call: TOOLS) -> str:
     if isinstance(tool_call, BashCommand):
         return tool_call.action_json.thread_id
-    if isinstance(tool_call, (Initialize, FileWriteOrEdit)):
+    if isinstance(
+        tool_call,
+        (Initialize, FileWriteOrEdit, ReadFiles, ReadImage, ContextSave),
+    ):
         return tool_call.thread_id
-    return ""
+    raise TypeError(f"Unsupported tool type: {type(tool_call)}")
 
 
 def restored_state(thread_id: str) -> BashState | None:
@@ -198,24 +194,29 @@ def restored_state(thread_id: str) -> BashState | None:
 
 def state_for_tool(tool_call: TOOLS) -> BashState:
     if isinstance(tool_call, Initialize) and tool_call.type == "first_call":
-        return new_state(None)
+        new = new_state(None)
+        BASH_STATES[new.current_thread_id] = new
+        return new
 
     thread_id = tool_thread_id(tool_call)
-    if thread_id:
-        state = BASH_STATES.get(thread_id)
-        if state is not None:
-            return state
-        state = restored_state(thread_id)
-        if state is not None:
-            BASH_STATES[thread_id] = state
-            return state
+    if not thread_id:
+        raise ValueError("A thread_id is required for this tool call")
 
-    assert BASH_STATE
-    return BASH_STATE
+    existing = BASH_STATES.get(thread_id)
+    if existing is not None:
+        return existing
+
+    restored = restored_state(thread_id)
+    if restored is None:
+        raise ValueError(
+            f"No saved WCGW state exists for thread_id `{thread_id}`; initialize it first"
+        )
+    BASH_STATES[thread_id] = restored
+    return restored
 
 
 async def main(shell_path: str = "") -> None:
-    global BASH_STATE, CUSTOM_INSTRUCTIONS
+    global BASH_STATE, CUSTOM_INSTRUCTIONS, STARTING_DIR, SHELL_PATH
     CONFIG.update(3, 55, 5)
     version = str(metadata.version("wcgw"))
 
@@ -224,11 +225,12 @@ async def main(shell_path: str = "") -> None:
 
     # starting_dir is inside tmp dir
     tmp_dir = get_tmpdir()
-    starting_dir = os.path.join(tmp_dir, "claude_playground")
+    STARTING_DIR = os.path.join(tmp_dir, "claude_playground")
+    SHELL_PATH = shell_path
 
     BASH_STATE = BashState(
         Console(),
-        starting_dir,
+        STARTING_DIR,
         None,
         None,
         None,
@@ -236,7 +238,7 @@ async def main(shell_path: str = "") -> None:
         True,
         None,
         None,
-        shell_path or None,
+        SHELL_PATH or None,
     )
     BASH_STATE.console.log("wcgw version: " + version)
     try:

--- a/src/wcgw/client/mcp_server/server.py
+++ b/src/wcgw/client/mcp_server/server.py
@@ -109,6 +109,8 @@ async def handle_call_tool(
     state = state_for_tool(tool_call)
 
     try:
+        if isinstance(tool_call, FileWriteOrEdit):
+            sync_legacy_whitelist_into_state(state)
         output_or_dones, _ = get_tool_output(
             Context(state, state.console),
             tool_call,
@@ -184,6 +186,11 @@ def tool_thread_id(tool_call: TOOLS) -> str:
     raise TypeError(f"Unsupported tool type: {type(tool_call)}")
 
 
+def sync_legacy_whitelist_into_state(state: BashState) -> None:
+    if BASH_STATE is not None and BASH_STATE is not state:
+        state.whitelist_for_overwrite.update(BASH_STATE.whitelist_for_overwrite)
+
+
 def restored_state(thread_id: str) -> BashState | None:
     state = new_state(None)
     if state.load_state_from_thread_id(thread_id):
@@ -200,7 +207,9 @@ def state_for_tool(tool_call: TOOLS) -> BashState:
 
     thread_id = tool_thread_id(tool_call)
     if not thread_id:
-        raise ValueError("A thread_id is required for this tool call")
+        if BASH_STATE is None:
+            raise RuntimeError("WCGW server state is not configured")
+        return BASH_STATE
 
     existing = BASH_STATES.get(thread_id)
     if existing is not None:
@@ -211,6 +220,7 @@ def state_for_tool(tool_call: TOOLS) -> BashState:
         raise ValueError(
             f"No saved WCGW state exists for thread_id `{thread_id}`; initialize it first"
         )
+    sync_legacy_whitelist_into_state(restored)
     BASH_STATES[thread_id] = restored
     return restored
 

--- a/src/wcgw/client/mcp_server/server.py
+++ b/src/wcgw/client/mcp_server/server.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from importlib import metadata
@@ -106,19 +107,21 @@ async def handle_call_tool(
 
     tool_type = which_tool_name(name)
     tool_call = parse_tool_by_name(name, arguments)
-    state = state_for_tool(tool_call)
+    state = await state_for_tool(tool_call)
 
     try:
         if isinstance(tool_call, FileWriteOrEdit):
             sync_legacy_whitelist_into_state(state)
-        output_or_dones, _ = get_tool_output(
-            Context(state, state.console),
-            tool_call,
-            0.0,
-            lambda x, y: ("", 0),
-            24000,  # coding_max_tokens
-            8000,  # noncoding_max_tokens
-        )
+        async with state_call_lock(state.current_thread_id):
+            output_or_dones, _ = await asyncio.to_thread(
+                get_tool_output,
+                Context(state, state.console),
+                tool_call,
+                0.0,
+                lambda x, y: ("", 0),
+                24000,  # coding_max_tokens
+                8000,  # noncoding_max_tokens
+            )
 
     except Exception as e:
         output_or_dones = [f"GOT EXCEPTION while calling tool. Error: {e}"]
@@ -155,9 +158,27 @@ Initialize call done.
 
 BASH_STATE: BashState | None = None
 BASH_STATES: dict[str, BashState] = {}
+STATE_CALL_LOCKS: dict[str, asyncio.Lock] = {}
+STATE_CREATION_LOCKS: dict[str, asyncio.Lock] = {}
 CUSTOM_INSTRUCTIONS = None
 STARTING_DIR = ""
 SHELL_PATH = ""
+
+
+def state_call_lock(thread_id: str) -> asyncio.Lock:
+    lock = STATE_CALL_LOCKS.get(thread_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        STATE_CALL_LOCKS[thread_id] = lock
+    return lock
+
+
+def state_creation_lock(thread_id: str) -> asyncio.Lock:
+    lock = STATE_CREATION_LOCKS.get(thread_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        STATE_CREATION_LOCKS[thread_id] = lock
+    return lock
 
 
 def new_state(thread_id: str | None) -> BashState:
@@ -199,9 +220,9 @@ def restored_state(thread_id: str) -> BashState | None:
     return None
 
 
-def state_for_tool(tool_call: TOOLS) -> BashState:
+async def state_for_tool(tool_call: TOOLS) -> BashState:
     if isinstance(tool_call, Initialize) and tool_call.type == "first_call":
-        new = new_state(None)
+        new = await asyncio.to_thread(new_state, None)
         BASH_STATES[new.current_thread_id] = new
         return new
 
@@ -215,14 +236,19 @@ def state_for_tool(tool_call: TOOLS) -> BashState:
     if existing is not None:
         return existing
 
-    restored = restored_state(thread_id)
-    if restored is None:
-        raise ValueError(
-            f"No saved WCGW state exists for thread_id `{thread_id}`; initialize it first"
-        )
-    sync_legacy_whitelist_into_state(restored)
-    BASH_STATES[thread_id] = restored
-    return restored
+    async with state_creation_lock(thread_id):
+        existing = BASH_STATES.get(thread_id)
+        if existing is not None:
+            return existing
+
+        restored = await asyncio.to_thread(restored_state, thread_id)
+        if restored is None:
+            raise ValueError(
+                f"No saved WCGW state exists for thread_id `{thread_id}`; initialize it first"
+            )
+        sync_legacy_whitelist_into_state(restored)
+        BASH_STATES[thread_id] = restored
+        return restored
 
 
 async def main(shell_path: str = "") -> None:

--- a/src/wcgw/client/mcp_server/server.py
+++ b/src/wcgw/client/mcp_server/server.py
@@ -13,10 +13,13 @@ from wcgw.client.modes import KTS
 from wcgw.client.tool_prompts import TOOL_PROMPTS
 
 from ...types_ import (
+    BashCommand,
+    FileWriteOrEdit,
     Initialize,
 )
 from ..bash_state.bash_state import CONFIG, BashState, get_tmpdir
 from ..tools import (
+    TOOLS,
     Context,
     get_tool_output,
     parse_tool_by_name,
@@ -100,17 +103,19 @@ async def handle_call_tool(
 
     tool_type = which_tool_name(name)
     tool_call = parse_tool_by_name(name, arguments)
+    state = state_for_tool(tool_call)
+    BASH_STATE = state
 
     try:
-        assert BASH_STATE
         output_or_dones, _ = get_tool_output(
-            Context(BASH_STATE, BASH_STATE.console),
+            Context(state, state.console),
             tool_call,
             0.0,
             lambda x, y: ("", 0),
             24000,  # coding_max_tokens
             8000,  # noncoding_max_tokens
         )
+        BASH_STATES[state.current_thread_id] = state
 
     except Exception as e:
         output_or_dones = [f"GOT EXCEPTION while calling tool. Error: {e}"]
@@ -145,8 +150,68 @@ Initialize call done.
     return content
 
 
-BASH_STATE = None
+BASH_STATE: BashState | None = None
+BASH_STATES: dict[str, BashState] = {}
 CUSTOM_INSTRUCTIONS = None
+
+
+def new_state(thread_id: str | None) -> BashState:
+    template = BASH_STATE
+    working_dir = (
+        template.cwd
+        if template is not None
+        else os.path.join(get_tmpdir(), "claude_playground")
+    )
+    use_screen = template.over_screen if template is not None else True
+    shell_path = template.shell_path if template is not None else os.environ.get(
+        "SHELL", "/bin/bash"
+    )
+    return BashState(
+        Console(),
+        working_dir,
+        None,
+        None,
+        None,
+        None,
+        use_screen,
+        None,
+        thread_id,
+        shell_path,
+    )
+
+
+def tool_thread_id(tool_call: TOOLS) -> str:
+    if isinstance(tool_call, BashCommand):
+        return tool_call.action_json.thread_id
+    if isinstance(tool_call, (Initialize, FileWriteOrEdit)):
+        return tool_call.thread_id
+    return ""
+
+
+def restored_state(thread_id: str) -> BashState | None:
+    state = new_state(None)
+    if state.load_state_from_thread_id(thread_id):
+        return state
+    state.cleanup()
+    return None
+
+
+def state_for_tool(tool_call: TOOLS) -> BashState:
+    if isinstance(tool_call, Initialize) and tool_call.type == "first_call":
+        return new_state(None)
+
+    thread_id = tool_thread_id(tool_call)
+    if thread_id:
+        state = BASH_STATES.get(thread_id)
+        if state is not None:
+            return state
+        state = restored_state(thread_id)
+        if state is not None:
+            BASH_STATES[thread_id] = state
+            return state
+
+    assert BASH_STATE
+    return BASH_STATE
 
 
 async def main(shell_path: str = "") -> None:
@@ -161,7 +226,7 @@ async def main(shell_path: str = "") -> None:
     tmp_dir = get_tmpdir()
     starting_dir = os.path.join(tmp_dir, "claude_playground")
 
-    with BashState(
+    BASH_STATE = BashState(
         Console(),
         starting_dir,
         None,
@@ -172,8 +237,9 @@ async def main(shell_path: str = "") -> None:
         None,
         None,
         shell_path or None,
-    ) as BASH_STATE:
-        BASH_STATE.console.log("wcgw version: " + version)
+    )
+    BASH_STATE.console.log("wcgw version: " + version)
+    try:
         # Run the server using stdin/stdout streams
         async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
             await server.run(
@@ -189,3 +255,14 @@ async def main(shell_path: str = "") -> None:
                 ),
                 raise_exceptions=False,
             )
+    finally:
+        states = {
+            id(state): state
+            for state in [BASH_STATE, *BASH_STATES.values()]
+            if state is not None
+        }
+        for state in states.values():
+            try:
+                state.cleanup()
+            except Exception:
+                logger.exception("failed to clean up WCGW shell state")

--- a/src/wcgw/client/tool_prompts.py
+++ b/src/wcgw/client/tool_prompts.py
@@ -58,6 +58,7 @@ TOOL_PROMPTS = [
         name="ReadFiles",
         description="""
 - Read full file content of one or more files.
+- Use the thread_id returned by Initialize for this conversation.
 - Provide absolute paths only (~ allowed)
 - Only if the task requires line numbers understanding:
     - You may extract a range of lines. E.g., `/path/to/file:1-10` for lines 1-10. You can drop start or end like `/path/to/file:1-` or `/path/to/file:-10` 
@@ -67,7 +68,7 @@ TOOL_PROMPTS = [
     Tool(
         inputSchema=remove_titles_from_schema(ReadImage.model_json_schema()),
         name="ReadImage",
-        description="Read an image from the shell.",
+        description="Read an image from the shell. Use the thread_id returned by Initialize for this conversation.",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
     ),
     Tool(
@@ -90,7 +91,8 @@ TOOL_PROMPTS = [
         inputSchema=remove_titles_from_schema(ContextSave.model_json_schema()),
         name="ContextSave",
         description="""
-Saves provided description and file contents of all the relevant file paths or globs in a single text file.
+ Saves provided description and file contents of all the relevant file paths or globs in a single text file.
+- Use the thread_id returned by Initialize for this conversation.
 - Provide random 3 word unique id or whatever user provided.
 - Leave project path as empty string if no project path""",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),

--- a/src/wcgw/client/tool_prompts.py
+++ b/src/wcgw/client/tool_prompts.py
@@ -58,7 +58,7 @@ TOOL_PROMPTS = [
         name="ReadFiles",
         description="""
 - Read full file content of one or more files.
-- Use the thread_id returned by Initialize for this conversation.
+- Use the thread_id returned by Initialize for this conversation when available; legacy clients may omit it.
 - Provide absolute paths only (~ allowed)
 - Only if the task requires line numbers understanding:
     - You may extract a range of lines. E.g., `/path/to/file:1-10` for lines 1-10. You can drop start or end like `/path/to/file:1-` or `/path/to/file:-10` 
@@ -68,7 +68,7 @@ TOOL_PROMPTS = [
     Tool(
         inputSchema=remove_titles_from_schema(ReadImage.model_json_schema()),
         name="ReadImage",
-        description="Read an image from the shell. Use the thread_id returned by Initialize for this conversation.",
+        description="Read an image from the shell. Use the thread_id returned by Initialize when available; legacy clients may omit it.",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
     ),
     Tool(
@@ -92,7 +92,7 @@ TOOL_PROMPTS = [
         name="ContextSave",
         description="""
  Saves provided description and file contents of all the relevant file paths or globs in a single text file.
-- Use the thread_id returned by Initialize for this conversation.
+- Use the thread_id returned by Initialize when available; legacy clients may omit it.
 - Provide random 3 word unique id or whatever user provided.
 - Leave project path as empty string if no project path""",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),

--- a/src/wcgw/client/tools.py
+++ b/src/wcgw/client/tools.py
@@ -630,7 +630,9 @@ def write_file(
                     paths_: list[str] = []
                     for start, end in unread_ranges:
                         paths_.append(path_ + ":" + f"{start}-{end}")
-                    paths_readfiles = ReadFiles(file_paths=paths_)
+                    paths_readfiles = ReadFiles(
+                        file_paths=paths_, thread_id=context.bash_state.current_thread_id
+                    )
                     readfiles, file_ranges_dict, truncated = read_files(
                         paths_readfiles.file_paths,
                         coding_max_tokens,

--- a/src/wcgw/types_.py
+++ b/src/wcgw/types_.py
@@ -245,6 +245,11 @@ class BashCommand(BaseModel):
 
 class ReadImage(BaseModel):
     file_path: str
+    thread_id: str
+
+    def model_post_init(self, __context: Any) -> None:
+        self.thread_id = normalize_thread_id(self.thread_id)
+        return super().model_post_init(__context)
 
 
 class WriteIfEmpty(BaseModel):
@@ -254,6 +259,7 @@ class WriteIfEmpty(BaseModel):
 
 class ReadFiles(BaseModel):
     file_paths: list[str]
+    thread_id: str
     _start_line_nums: List[Optional[int]] = PrivateAttr(default_factory=lambda: [])
     _end_line_nums: List[Optional[int]] = PrivateAttr(default_factory=lambda: [])
 
@@ -272,6 +278,7 @@ class ReadFiles(BaseModel):
         return self._end_line_nums
 
     def model_post_init(self, __context: Any) -> None:
+        self.thread_id = normalize_thread_id(self.thread_id)
         # Parse file paths for line ranges and store them in private attributes
         self._start_line_nums = []
         self._end_line_nums = []
@@ -373,6 +380,11 @@ class ContextSave(BaseModel):
     project_root_path: str
     description: str
     relevant_file_globs: list[str]
+    thread_id: str
+
+    def model_post_init(self, __context: Any) -> None:
+        self.thread_id = normalize_thread_id(self.thread_id)
+        return super().model_post_init(__context)
 
 
 class Console(Protocol):

--- a/src/wcgw/types_.py
+++ b/src/wcgw/types_.py
@@ -245,7 +245,7 @@ class BashCommand(BaseModel):
 
 class ReadImage(BaseModel):
     file_path: str
-    thread_id: str
+    thread_id: str = ""
 
     def model_post_init(self, __context: Any) -> None:
         self.thread_id = normalize_thread_id(self.thread_id)
@@ -259,7 +259,7 @@ class WriteIfEmpty(BaseModel):
 
 class ReadFiles(BaseModel):
     file_paths: list[str]
-    thread_id: str
+    thread_id: str = ""
     _start_line_nums: List[Optional[int]] = PrivateAttr(default_factory=lambda: [])
     _end_line_nums: List[Optional[int]] = PrivateAttr(default_factory=lambda: [])
 
@@ -380,7 +380,7 @@ class ContextSave(BaseModel):
     project_root_path: str
     description: str
     relevant_file_globs: list[str]
-    thread_id: str
+    thread_id: str = ""
 
     def model_post_init(self, __context: Any) -> None:
         self.thread_id = normalize_thread_id(self.thread_id)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -164,6 +164,10 @@ async def test_handle_list_tools():
                 "send_ascii",
             }
             assert required_types.issubset(type_refs)
+        elif tool.name in {"ReadFiles", "ReadImage", "ContextSave"}:
+            properties = tool.inputSchema["properties"]
+            assert "thread_id" in properties
+            assert "thread_id" not in tool.inputSchema.get("required", [])
         elif tool.name == "FileWriteOrEdit":
             properties = tool.inputSchema["properties"]
             assert "file_path" in properties
@@ -319,6 +323,43 @@ async def test_handle_call_tool_routes_read_tools_by_thread_id(setup_bash_state)
 
 
 @pytest.mark.asyncio
+async def test_legacy_read_authorizes_later_threaded_write(setup_bash_state, tmp_path):
+    second_state = server.new_state("thread_b")
+    server.BASH_STATES["thread_b"] = second_state
+    test_file = tmp_path / "legacy.txt"
+    test_file.write_text("legacy")
+
+    read_result = await handle_call_tool(
+        "ReadFiles", {"file_paths": [str(test_file)]}
+    )
+    assert "legacy" in read_result[0].text
+    assert server.BASH_STATE is not None
+    assert str(test_file) in server.BASH_STATE.whitelist_for_overwrite
+    assert str(test_file) not in second_state.whitelist_for_overwrite
+
+    def inspect_write_state(*args, **kwargs):
+        context = args[0]
+        authorized = str(test_file) in context.bash_state.whitelist_for_overwrite
+        return [str(authorized)], 0.0
+
+    with patch(
+        "wcgw.client.mcp_server.server.get_tool_output",
+        side_effect=inspect_write_state,
+    ):
+        write_result = await handle_call_tool(
+            "FileWriteOrEdit",
+            {
+                "file_path": str(test_file),
+                "percentage_to_change": 100,
+                "text_or_search_replace_blocks": "replacement",
+                "thread_id": "thread_b",
+            },
+        )
+
+    assert write_result[0].text == "True"
+
+
+@pytest.mark.asyncio
 async def test_handle_call_tool_image_response(setup_bash_state):
     # Test handling of image content
     mock_image_data = "fake_image_data"
@@ -334,13 +375,7 @@ async def test_handle_call_tool_image_response(setup_bash_state):
         return_value=([mock_image], None),
     ):
         assert server.BASH_STATE is not None
-        result = await handle_call_tool(
-            "ReadImage",
-            {
-                "file_path": "test.png",
-                "thread_id": server.BASH_STATE.current_thread_id,
-            },
-        )
+        result = await handle_call_tool("ReadImage", {"file_path": "test.png"})
         assert result[0].data == mock_image_data
         assert result[0].mimeType == mock_media_type
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -40,6 +40,7 @@ def setup_bash_state():
     bash_state = BashState(Console(), home_dir, None, None, None, "wcgw", False, None)
     server.BASH_STATES.clear()
     server.BASH_STATE = bash_state
+    server.BASH_STATES[bash_state.current_thread_id] = bash_state
 
     try:
         yield server.BASH_STATE
@@ -189,10 +190,15 @@ async def test_handle_call_tool(setup_bash_state):
     assert len(result) > 0
     assert isinstance(result[0], TextContent)
     assert "Initialize" in result[0].text
+    initialized_thread = re.search(r"Use thread_id=(\w+)", result[0].text)
+    assert initialized_thread is not None
 
     # Test JSON string argument handling
     json_args = {
-        "action_json": {"command": "ls", "thread_id": ""},
+        "action_json": {
+            "command": "ls",
+            "thread_id": initialized_thread.group(1),
+        },
     }
     result = await handle_call_tool("BashCommand", json_args)
     assert isinstance(result, list)
@@ -215,7 +221,10 @@ async def test_handle_call_tool(setup_bash_state):
         result = await handle_call_tool(
             "BashCommand",
             {
-                "action_json": {"command": "ls", "thread_id": ""},
+                "action_json": {
+                    "command": "ls",
+                    "thread_id": initialized_thread.group(1),
+                },
             },
         )
         assert "GOT EXCEPTION" in result[0].text
@@ -287,6 +296,29 @@ async def test_handle_call_tool_preserves_shells_across_thread_ids(
 
 
 @pytest.mark.asyncio
+async def test_handle_call_tool_routes_read_tools_by_thread_id(setup_bash_state):
+    first_state = server.new_state("thread_a")
+    second_state = server.new_state("thread_b")
+    server.BASH_STATES["thread_a"] = first_state
+    server.BASH_STATES["thread_b"] = second_state
+
+    def fake_get_tool_output(*args, **kwargs):
+        context = args[0]
+        return [context.bash_state.current_thread_id], 0.0
+
+    with patch(
+        "wcgw.client.mcp_server.server.get_tool_output",
+        side_effect=fake_get_tool_output,
+    ):
+        result = await handle_call_tool(
+            "ReadFiles",
+            {"file_paths": ["/tmp/example"], "thread_id": "thread_b"},
+        )
+
+    assert result[0].text == "thread_b"
+
+
+@pytest.mark.asyncio
 async def test_handle_call_tool_image_response(setup_bash_state):
     # Test handling of image content
     mock_image_data = "fake_image_data"
@@ -301,7 +333,14 @@ async def test_handle_call_tool_image_response(setup_bash_state):
         "wcgw.client.mcp_server.server.get_tool_output",
         return_value=([mock_image], None),
     ):
-        result = await handle_call_tool("ReadImage", {"file_path": "test.png"})
+        assert server.BASH_STATE is not None
+        result = await handle_call_tool(
+            "ReadImage",
+            {
+                "file_path": "test.png",
+                "thread_id": server.BASH_STATE.current_thread_id,
+            },
+        )
         assert result[0].data == mock_image_data
         assert result[0].mimeType == mock_media_type
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,4 +1,5 @@
 import os
+import re
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -37,15 +38,23 @@ def setup_bash_state():
     # Create new BashState with mode
     home_dir = os.path.expanduser("~")
     bash_state = BashState(Console(), home_dir, None, None, None, "wcgw", False, None)
+    server.BASH_STATES.clear()
     server.BASH_STATE = bash_state
 
     try:
         yield server.BASH_STATE
     finally:
-        try:
-            bash_state.cleanup()
-        except Exception as e:
-            print(f"Error during cleanup: {e}")
+        states = {
+            id(state): state
+            for state in [bash_state, server.BASH_STATE, *server.BASH_STATES.values()]
+            if state is not None
+        }
+        for state in states.values():
+            try:
+                state.cleanup()
+            except Exception as e:
+                print(f"Error during cleanup: {e}")
+        server.BASH_STATES.clear()
         server.BASH_STATE = None
 
 
@@ -210,6 +219,71 @@ async def test_handle_call_tool(setup_bash_state):
             },
         )
         assert "GOT EXCEPTION" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_preserves_shells_across_thread_ids(
+    setup_bash_state, tmp_path
+):
+    first_workspace = tmp_path / "first"
+    second_workspace = tmp_path / "second"
+    first_workspace.mkdir()
+    second_workspace.mkdir()
+
+    init_args = {
+        "initial_files_to_read": [],
+        "task_id_to_resume": "",
+        "mode_name": "wcgw",
+        "type": "first_call",
+        "thread_id": "",
+    }
+    first_init = await handle_call_tool(
+        "Initialize", {**init_args, "any_workspace_path": str(first_workspace)}
+    )
+    first_match = re.search(r"Use thread_id=(\w+)", first_init[0].text)
+    assert first_match is not None
+    first_thread_id = first_match.group(1)
+
+    pending = await handle_call_tool(
+        "BashCommand",
+        {
+            "type": "command",
+            "command": "sleep 10",
+            "thread_id": first_thread_id,
+            "wait_for_seconds": 0.1,
+        },
+    )
+    assert "status = still running" in pending[0].text
+
+    second_init = await handle_call_tool(
+        "Initialize", {**init_args, "any_workspace_path": str(second_workspace)}
+    )
+    second_match = re.search(r"Use thread_id=(\w+)", second_init[0].text)
+    assert second_match is not None
+    second_thread_id = second_match.group(1)
+    assert second_thread_id != first_thread_id
+
+    second_pwd = await handle_call_tool(
+        "BashCommand",
+        {
+            "type": "command",
+            "command": "pwd",
+            "thread_id": second_thread_id,
+            "wait_for_seconds": 0.5,
+        },
+    )
+    assert str(second_workspace) in second_pwd[0].text
+
+    first_status = await handle_call_tool(
+        "BashCommand",
+        {
+            "type": "status_check",
+            "status_check": True,
+            "thread_id": first_thread_id,
+            "wait_for_seconds": 0.1,
+        },
+    )
+    assert "status = still running" in first_status[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,8 @@
+import asyncio
 import os
 import re
+import threading
+import time
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -39,6 +42,8 @@ def setup_bash_state():
     home_dir = os.path.expanduser("~")
     bash_state = BashState(Console(), home_dir, None, None, None, "wcgw", False, None)
     server.BASH_STATES.clear()
+    server.STATE_CALL_LOCKS.clear()
+    server.STATE_CREATION_LOCKS.clear()
     server.BASH_STATE = bash_state
     server.BASH_STATES[bash_state.current_thread_id] = bash_state
 
@@ -56,6 +61,8 @@ def setup_bash_state():
             except Exception as e:
                 print(f"Error during cleanup: {e}")
         server.BASH_STATES.clear()
+        server.STATE_CALL_LOCKS.clear()
+        server.STATE_CREATION_LOCKS.clear()
         server.BASH_STATE = None
 
 
@@ -297,6 +304,156 @@ async def test_handle_call_tool_preserves_shells_across_thread_ids(
         },
     )
     assert "status = still running" in first_status[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_runs_different_shell_states_concurrently(
+    setup_bash_state,
+):
+    first_state = server.new_state("thread_a")
+    second_state = server.new_state("thread_b")
+    server.BASH_STATES["thread_a"] = first_state
+    server.BASH_STATES["thread_b"] = second_state
+    call_order: list[str] = []
+
+    def fake_get_tool_output(*args, **kwargs):
+        tool_call = args[1]
+        thread_id = tool_call.action_json.thread_id
+        call_order.append(f"{thread_id}:start")
+        if thread_id == "thread_a":
+            time.sleep(0.2)
+        call_order.append(f"{thread_id}:end")
+        return ["ok"], 0.0
+
+    with patch(
+        "wcgw.client.mcp_server.server.get_tool_output",
+        side_effect=fake_get_tool_output,
+    ):
+        first_call = asyncio.create_task(
+            handle_call_tool(
+                "BashCommand",
+                {"type": "command", "command": "first", "thread_id": "thread_a"},
+            )
+        )
+        await asyncio.sleep(0.02)
+        second_call = asyncio.create_task(
+            handle_call_tool(
+                "BashCommand",
+                {"type": "command", "command": "second", "thread_id": "thread_b"},
+            )
+        )
+        await asyncio.gather(first_call, second_call)
+
+    assert call_order.index("thread_b:end") < call_order.index("thread_a:end")
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_serializes_calls_for_same_thread_id(
+    setup_bash_state,
+):
+    state = server.new_state("thread_a")
+    server.BASH_STATES["thread_a"] = state
+    counter_lock = threading.Lock()
+    active_calls = 0
+    max_active_calls = 0
+
+    def fake_get_tool_output(*args, **kwargs):
+        nonlocal active_calls, max_active_calls
+        with counter_lock:
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+        time.sleep(0.05)
+        with counter_lock:
+            active_calls -= 1
+        return ["ok"], 0.0
+
+    with patch(
+        "wcgw.client.mcp_server.server.get_tool_output",
+        side_effect=fake_get_tool_output,
+    ):
+        await asyncio.gather(
+            handle_call_tool(
+                "BashCommand",
+                {"type": "command", "command": "first", "thread_id": "thread_a"},
+            ),
+            handle_call_tool(
+                "BashCommand",
+                {"type": "command", "command": "second", "thread_id": "thread_a"},
+            ),
+        )
+
+    assert max_active_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_first_call_state_creation_does_not_block_event_loop(setup_bash_state):
+    assert server.BASH_STATE is not None
+    created_state = server.BASH_STATE
+
+    def slow_new_state(thread_id):
+        time.sleep(0.2)
+        return created_state
+
+    with (
+        patch("wcgw.client.mcp_server.server.new_state", side_effect=slow_new_state),
+        patch(
+            "wcgw.client.mcp_server.server.get_tool_output",
+            return_value=(["ok"], 0.0),
+        ),
+    ):
+        call = asyncio.create_task(
+            handle_call_tool(
+                "Initialize",
+                {
+                    "any_workspace_path": "",
+                    "initial_files_to_read": [],
+                    "task_id_to_resume": "",
+                    "mode_name": "wcgw",
+                    "type": "first_call",
+                    "thread_id": "",
+                },
+            )
+        )
+        started = time.monotonic()
+        await asyncio.sleep(0.02)
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.1
+        await call
+
+
+@pytest.mark.asyncio
+async def test_restore_is_atomic_for_same_thread_id(setup_bash_state):
+    restored_state = server.new_state("restored")
+    server.BASH_STATES.pop("restored", None)
+    restore_calls = 0
+    restore_lock = threading.Lock()
+
+    def slow_restore(thread_id):
+        nonlocal restore_calls
+        with restore_lock:
+            restore_calls += 1
+        time.sleep(0.1)
+        return restored_state
+
+    with (
+        patch("wcgw.client.mcp_server.server.restored_state", side_effect=slow_restore),
+        patch(
+            "wcgw.client.mcp_server.server.get_tool_output",
+            return_value=(["ok"], 0.0),
+        ),
+    ):
+        await asyncio.gather(
+            handle_call_tool(
+                "BashCommand",
+                {"type": "command", "command": "first", "thread_id": "restored"},
+            ),
+            handle_call_tool(
+                "BashCommand",
+                {"type": "command", "command": "second", "thread_id": "restored"},
+            ),
+        )
+
+    assert restore_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -1,0 +1,103 @@
+import asyncio
+import os
+import re
+import shutil
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def result_text(result) -> str:
+    return "\n".join(getattr(item, "text", "") for item in result.content)
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_keeps_conversation_shells_concurrent(tmp_path) -> None:
+    executable = shutil.which("wcgw_mcp")
+    assert executable is not None
+    env = dict(os.environ)
+    env["HOME"] = str(tmp_path)
+    env["SHELL"] = "/bin/bash"
+    env["XDG_STATE_HOME"] = str(tmp_path / "state")
+
+    params = StdioServerParameters(
+        command=executable,
+        args=["--shell", "/bin/bash"],
+        env=env,
+        cwd=str(tmp_path),
+    )
+    async with stdio_client(params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            init_args = {
+                "type": "first_call",
+                "any_workspace_path": "",
+                "initial_files_to_read": [],
+                "task_id_to_resume": "",
+                "mode_name": "wcgw",
+                "thread_id": "",
+            }
+            first_init, second_init = await asyncio.gather(
+                session.call_tool("Initialize", init_args),
+                session.call_tool("Initialize", init_args),
+            )
+            first_match = re.search(r"Use thread_id=(\w+)", result_text(first_init))
+            second_match = re.search(r"Use thread_id=(\w+)", result_text(second_init))
+            assert first_match is not None
+            assert second_match is not None
+            first_thread = first_match.group(1)
+            second_thread = second_match.group(1)
+            assert first_thread != second_thread
+
+            # Warm both shells so shell startup time is not part of the concurrency assertion.
+            await asyncio.gather(
+                session.call_tool(
+                    "BashCommand",
+                    {
+                        "type": "command",
+                        "command": "pwd",
+                        "thread_id": first_thread,
+                        "wait_for_seconds": 0.5,
+                    },
+                ),
+                session.call_tool(
+                    "BashCommand",
+                    {
+                        "type": "command",
+                        "command": "pwd",
+                        "thread_id": second_thread,
+                        "wait_for_seconds": 0.5,
+                    },
+                ),
+            )
+
+            long_call = asyncio.create_task(
+                session.call_tool(
+                    "BashCommand",
+                    {
+                        "type": "command",
+                        "command": "sleep 1",
+                        "thread_id": first_thread,
+                        "wait_for_seconds": 2,
+                    },
+                )
+            )
+            await asyncio.sleep(0.02)
+            short_call = asyncio.create_task(
+                session.call_tool(
+                    "BashCommand",
+                    {
+                        "type": "command",
+                        "command": "pwd",
+                        "thread_id": second_thread,
+                        "wait_for_seconds": 0.5,
+                    },
+                )
+            )
+            short_result = await asyncio.wait_for(short_call, timeout=2)
+            assert "status = process exited" in result_text(short_result)
+            assert not long_call.done()
+
+            long_result = await asyncio.wait_for(long_call, timeout=2)
+            assert "status = process exited" in result_text(long_result)

--- a/tests/test_readfiles.py
+++ b/tests/test_readfiles.py
@@ -1,84 +1,84 @@
 import os
 import tempfile
-from typing import Optional
 
 from wcgw.types_ import ReadFiles
 
 
 def test_readfiles_line_number_parsing():
     # Create a temporary file
-    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
         tmp.write("Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n")
         tmp_path = tmp.name
-    
+
     try:
         # Test with no line numbers
-        read_files = ReadFiles(file_paths=[tmp_path])
+        read_files = ReadFiles(file_paths=[tmp_path], thread_id="test")
         assert read_files.file_paths == [tmp_path]
         assert read_files.start_line_nums == [None]
         assert read_files.end_line_nums == [None]
-        
+
         # Test with start line only (e.g., file.py:2)
-        read_files = ReadFiles(file_paths=[f"{tmp_path}:2"])
+        read_files = ReadFiles(file_paths=[f"{tmp_path}:2"], thread_id="test")
         assert read_files.file_paths == [tmp_path]
         assert read_files.start_line_nums == [2]
         assert read_files.end_line_nums == [None]
-        
+
         # Test with end line only (e.g., file.py:-3)
-        read_files = ReadFiles(file_paths=[f"{tmp_path}:-3"])
+        read_files = ReadFiles(file_paths=[f"{tmp_path}:-3"], thread_id="test")
         assert read_files.file_paths == [tmp_path]
         assert read_files.start_line_nums == [None]
         assert read_files.end_line_nums == [3]
-        
+
         # Test with start and end lines (e.g., file.py:2-4)
-        read_files = ReadFiles(file_paths=[f"{tmp_path}:2-4"])
+        read_files = ReadFiles(file_paths=[f"{tmp_path}:2-4"], thread_id="test")
         assert read_files.file_paths == [tmp_path]
         assert read_files.start_line_nums == [2]
         assert read_files.end_line_nums == [4]
-        
+
         # Test with start line and beyond (e.g., file.py:5-)
-        read_files = ReadFiles(file_paths=[f"{tmp_path}:5-"])
+        read_files = ReadFiles(file_paths=[f"{tmp_path}:5-"], thread_id="test")
         assert read_files.file_paths == [tmp_path]
         assert read_files.start_line_nums == [5]
         assert read_files.end_line_nums == [None]
-        
+
         # Test with multiple files
-        read_files = ReadFiles(file_paths=[
-            tmp_path,
-            f"{tmp_path}:2-3",
-            f"{tmp_path}:1-"
-        ])
+        read_files = ReadFiles(
+            file_paths=[tmp_path, f"{tmp_path}:2-3", f"{tmp_path}:1-"],
+            thread_id="test",
+        )
         assert read_files.file_paths == [tmp_path, tmp_path, tmp_path]
         assert read_files.start_line_nums == [None, 2, 1]
         assert read_files.end_line_nums == [None, 3, None]
-        
+
         # Test with invalid line numbers
-        read_files = ReadFiles(file_paths=[f"{tmp_path}:invalid-line"])
-        assert read_files.file_paths == [f"{tmp_path}:invalid-line"]  # Should keep the whole path
+        read_files = ReadFiles(
+            file_paths=[f"{tmp_path}:invalid-line"], thread_id="test"
+        )
+        assert read_files.file_paths == [f"{tmp_path}:invalid-line"]
         assert read_files.start_line_nums == [None]
         assert read_files.end_line_nums == [None]
-        
+
         # Test with files that legitimately contain colons
         filename_with_colon = f"{tmp_path}:colon_in_name"
-        read_files = ReadFiles(file_paths=[filename_with_colon])
-        assert read_files.file_paths == [filename_with_colon]  # Should keep the whole path
+        read_files = ReadFiles(file_paths=[filename_with_colon], thread_id="test")
+        assert read_files.file_paths == [filename_with_colon]
         assert read_files.start_line_nums == [None]
         assert read_files.end_line_nums == [None]
-        
+
         # Test with URLs that contain colons
         url_path = "/path/to/http://example.com/file.txt"
-        read_files = ReadFiles(file_paths=[url_path])
-        assert read_files.file_paths == [url_path]  # Should keep the whole path
+        read_files = ReadFiles(file_paths=[url_path], thread_id="test")
+        assert read_files.file_paths == [url_path]
         assert read_files.start_line_nums == [None]
         assert read_files.end_line_nums == [None]
-        
+
         # Test with URLs that contain colons followed by valid line numbers
         url_path_with_line = "/path/to/http://example.com/file.txt:10-20"
-        read_files = ReadFiles(file_paths=[url_path_with_line])
+        read_files = ReadFiles(file_paths=[url_path_with_line], thread_id="test")
         assert read_files.file_paths == ["/path/to/http://example.com/file.txt"]
         assert read_files.start_line_nums == [10]
         assert read_files.end_line_nums == [20]
-        
+
     finally:
         # Clean up: remove the temporary file
         os.unlink(tmp_path)

--- a/tests/test_shell_startup.py
+++ b/tests/test_shell_startup.py
@@ -1,0 +1,66 @@
+import re
+from pathlib import Path
+
+from wcgw.client.bash_state.bash_state import (
+    PROMPT_CONST,
+    ensure_wcgw_block_in_rc_file,
+    generate_thread_id,
+    start_shell,
+)
+from wcgw.types_ import Console
+
+
+class RecordingConsole(Console):
+    def __init__(self) -> None:
+        self.logs: list[str] = []
+        self.prints: list[str] = []
+
+    def log(self, msg: str) -> None:
+        self.logs.append(msg)
+
+    def print(self, msg: str) -> None:
+        self.prints.append(msg)
+
+
+def test_fallback_shell_preserves_initial_directory(tmp_path: Path) -> None:
+    shell, _ = start_shell(
+        False,
+        str(tmp_path),
+        RecordingConsole(),
+        False,
+        "/definitely/not-a-shell",
+    )
+    try:
+        shell.sendline("pwd")
+        shell.expect(re.escape(str(tmp_path)), timeout=3)
+        shell.expect(PROMPT_CONST, timeout=3)
+    finally:
+        shell.close(force=True)
+
+
+def test_zsh_block_upgrades_existing_config(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    zshrc = tmp_path / ".zshrc"
+    zshrc.write_text(
+        "before\n"
+        "# --WCGW_ENVIRONMENT_START--\n"
+        "if [ -n \"$IN_WCGW_ENVIRONMENT\" ]; then\n"
+        " old-wcgw-hook\n"
+        "fi\n"
+        "# --WCGW_ENVIRONMENT_END--\n"
+        "after\n"
+    )
+
+    ensure_wcgw_block_in_rc_file("/usr/bin/zsh", RecordingConsole())
+
+    content = zshrc.read_text()
+    assert "before\n" in content
+    assert "after\n" in content
+    assert "old-wcgw-hook" not in content
+    assert "autoload -Uz add-zsh-hook" in content
+    assert "add-zsh-hook -d precmd prmptcmdwcgw" in content
+    assert "add-zsh-hook precmd prmptcmdwcgw" in content
+
+
+def test_generated_thread_id_has_collision_resistant_shape() -> None:
+    assert re.fullmatch(r"i[0-9a-f]{32}", generate_thread_id()) is not None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -141,6 +141,7 @@ def test_initialize(context: Context, temp_dir: str) -> None:
         project_root_path=temp_dir,
         description="Test context",
         relevant_file_globs=["*.txt"],
+        thread_id=context.bash_state.current_thread_id,
     )
     get_tool_output(
         context, save_args, 1.0, lambda x, y: ("", 0.0), 8000, 4000
@@ -176,6 +177,7 @@ def test_initialize(context: Context, temp_dir: str) -> None:
         project_root_path=temp_dir,
         description="Test context with mode switch",
         relevant_file_globs=["*.txt"],
+        thread_id=context.bash_state.current_thread_id,
     )
     get_tool_output(
         context, save_args, 1.0, lambda x, y: ("", 0.0), 8000, 4000
@@ -491,7 +493,9 @@ def test_write_and_read_file(context: Context, temp_dir: str) -> None:
     assert "Success" in outputs[0]
 
     # Test reading the file back
-    read_args = ReadFiles(file_paths=[test_file])
+    read_args = ReadFiles(
+        file_paths=[test_file], thread_id=context.bash_state.current_thread_id
+    )
     outputs, _ = get_tool_output(
         context, read_args, 1.0, lambda x, y: ("", 0.0), 8000, 4000
     )
@@ -536,7 +540,9 @@ def test_write_and_read_file(context: Context, temp_dir: str) -> None:
     )  # Should fail with exception
 
     # Test writing after reading the file (should succeed with warning)
-    read_args = ReadFiles(file_paths=[test_file2])
+    read_args = ReadFiles(
+        file_paths=[test_file2], thread_id=context.bash_state.current_thread_id
+    )
     outputs, _ = get_tool_output(
         context, read_args, 1.0, lambda x, y: ("", 0.0), 8000, 4000
     )
@@ -554,7 +560,9 @@ def test_write_and_read_file(context: Context, temp_dir: str) -> None:
     assert "Success" in outputs[0]
 
     # Verify the new content was written
-    read_args = ReadFiles(file_paths=[test_file2])
+    read_args = ReadFiles(
+        file_paths=[test_file2], thread_id=context.bash_state.current_thread_id
+    )
     outputs, _ = get_tool_output(
         context, read_args, 1.0, lambda x, y: ("", 0.0), 8000, 4000
     )
@@ -592,6 +600,7 @@ def test_context_save(context: Context, temp_dir: str) -> None:
         project_root_path=temp_dir,
         description="Test save",
         relevant_file_globs=["*.txt"],
+        thread_id=context.bash_state.current_thread_id,
     )
 
     outputs, _ = get_tool_output(
@@ -892,7 +901,9 @@ def test_read_image(context: Context, temp_dir: str) -> None:
         )
 
     # Test reading image
-    read_args = ReadImage(file_path=test_image)
+    read_args = ReadImage(
+        file_path=test_image, thread_id=context.bash_state.current_thread_id
+    )
     outputs, _ = get_tool_output(
         context, read_args, 1.0, lambda x, y: ("", 0.0), 8000, 4000
     )
@@ -988,7 +999,9 @@ def test_write_empty_file_and_read(context: Context, temp_dir: str) -> None:
     assert len(outputs) == 1
     assert "Success" in outputs[0]
 
-    read_args = ReadFiles(file_paths=[test_file])
+    read_args = ReadFiles(
+        file_paths=[test_file], thread_id=context.bash_state.current_thread_id
+    )
     outputs, _ = get_tool_output(
         context, read_args, 1.0, lambda x, y: ("", 0.0), 8000, 4000
     )
@@ -1011,7 +1024,10 @@ def test_error_cases(context: Context, temp_dir: str) -> None:
     )
 
     # Test reading non-existent file
-    read_args = ReadFiles(file_paths=[os.path.join(temp_dir, "nonexistent.txt")])
+    read_args = ReadFiles(
+        file_paths=[os.path.join(temp_dir, "nonexistent.txt")],
+        thread_id=context.bash_state.current_thread_id,
+    )
     outputs, _ = get_tool_output(
         context, read_args, 1.0, lambda x, y: ("", 0.0), 8000, 4000
     )


### PR DESCRIPTION
## Summary
- isolate WCGW shell state by explicit conversation/thread IDs
- preserve backward compatibility for cached read-tool schemas
- keep same-thread tool calls serialized while allowing different conversation shells to execute concurrently
- move blocking shell/state work off the asyncio event loop
- make same-thread state restoration atomic
- add direct MCP transport concurrency regression coverage

## Validation
- focused state/concurrency/compatibility tests pass
- real stdio MCP transport concurrency test passes
- `mypy --strict src/wcgw` passes